### PR TITLE
Se agrega fix para tipos de gobierno nulos creados como administradores.

### DIFF
--- a/app/views/members/index.html.haml
+++ b/app/views/members/index.html.haml
@@ -26,7 +26,7 @@
               = user.government_name
             %hr
             %p.datasets
-              = user.government_type.capitalize
+              = !user.government_type.nil? ?  user.government_type.capitalize : "Miembro"
             %div.hidden
               %p.herramientas-titulo.text-center
                 Herramientas utilizadas:


### PR DESCRIPTION
Se agrega fix para mostrar también miembros que no tienen tipo de gobierno en la vista de miembros, se corrigió porque había algunos nulos que causaban excepción.