### PR TITLE
Se corrigen textos, se cambia Monterrey por Nuevo León 

### DIFF
--- a/app/services/user_registrations.rb
+++ b/app/services/user_registrations.rb
@@ -4,8 +4,8 @@ module UserRegistrations
       'Iztapalapa', 'Magdalena Contreras', 'Miguel Hidalgo', 'Milpa Alta', 'Tlahuac', 'Tlalpan', 'Venustiano Carranza', 'Xochimilco']
   end
   def self.states_options
-      ['Aguascalientes','Baja California Norte', 'Baja California Sur ','Campeche ','Chiapas ','Chihuahua', 'Coahuila','Colima ', 'Durango', 'Guanajuato', 
-        'Guerrero  ', 'Hidalgo ','Guadalajara','Edo. México ','Michoacán ','Morelos ','Nayarit','Monterrey','Oaxaca', 'Puebla ','Querétaro', 'Quintana Roo', 
-        'San Luís Potosí', 'Sinaloa ', 'Sonora ', 'Tabasco',  'Tamaulipas', 'Tlaxcala ', 'Veracruz', 'Yucatán ', 'Zacatecas', 'Distrito Federal' ]
+      ['Aguascalientes','Baja California Norte', 'Baja California Sur ','Campeche ','Chiapas ','Chihuahua', 'Coahuila','Colima', 'Durango', 'Guanajuato',
+        'Guerrero', 'Hidalgo','Jalisco','Edo. México','Michoacán','Morelos','Nayarit','Nuevo León','Oaxaca', 'Puebla','Querétaro', 'Quintana Roo',
+        'San Luís Potosí', 'Sinaloa', 'Sonora', 'Tabasco',  'Tamaulipas', 'Tlaxcala', 'Veracruz', 'Yucatán ', 'Zacatecas', 'Distrito Federal' ]
   end
 end 


### PR DESCRIPTION
También Guadalajara por Jalísco, la información estaba erronea se quitan también espacios de los nombres de algunos estados.