### PR TITLE
En la vista de miembros de la red se agrega filtro para solo ver usuarios

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -13,7 +13,7 @@ class MembersController < ApplicationController
     end
 
     def set_user_filter
-      @user = User.all
+      @user = User.where(government_type: ['delegacion', 'municipal','estatal'])
       unless params[:post].nil?
         @type = params[:post][:government_type]
         if @type == 'Delegacional'


### PR DESCRIPTION
que tienen un government_type: delegacion, municipal o estatal